### PR TITLE
posts#create 권한 추가함

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -27,6 +27,7 @@ class PostsController < ApplicationController
   # POST /posts
   # POST /posts.json
   def create
+    authorize_action_for Post, for: @bulletin
     @post = @bulletin.posts.new(post_params)
     @post.writer = current_user
 

--- a/app/models/favlink.rb
+++ b/app/models/favlink.rb
@@ -11,6 +11,7 @@
 #  bundlelink_id :integer
 #  created_at    :datetime
 #  updated_at    :datetime
+#  capture_loc   :string(255)
 #
 
 class Favlink < ActiveRecord::Base

--- a/spec/factories/favlinks.rb
+++ b/spec/factories/favlinks.rb
@@ -11,6 +11,7 @@
 #  bundlelink_id :integer
 #  created_at    :datetime
 #  updated_at    :datetime
+#  capture_loc   :string(255)
 #
 
 # Read about factories at https://github.com/thoughtbot/factory_girl

--- a/spec/models/favlink_spec.rb
+++ b/spec/models/favlink_spec.rb
@@ -11,6 +11,7 @@
 #  bundlelink_id :integer
 #  created_at    :datetime
 #  updated_at    :datetime
+#  capture_loc   :string(255)
 #
 
 require 'spec_helper'


### PR DESCRIPTION
오늘 모임에서 추가했던 posts#create 액션의 권한 추가한 부분입니다. 

``` ruby
def create
  authorize_action_for Post, for: @bulletin
  ...
end
```
