### PR TITLE
운영환경에서 로그를 logentries 서비스에 전송

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,10 @@ gem 'webshots', github: 'rorlab/webshots'
 gem 'rails_12factor', group: :production
 gem 'mysql2', group: :production
 
+group :production do
+  gem 'le'
+end
+
 group :development do
   gem 'annotate'
   gem 'better_errors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,6 +125,7 @@ GEM
     json (1.8.1)
     launchy (2.4.2)
       addressable (~> 2.3)
+    le (2.3.9)
     letter_opener (1.2.0)
       launchy (~> 2.2)
     listen (2.7.8)
@@ -288,6 +289,7 @@ DEPENDENCIES
   jquery-rails
   jquery-turbolinks
   launchy (~> 2.4.2)
+  le
   letter_opener
   mini_magick
   mysql2

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ export RORLA_SECRET_KEY_BASE=암호화키
 export MANDRILL_USERNAME=email@email.com
 export MANDRILL_APIKEY=password
 export RORLA_HOST=localhost
+export RORLA_LOGENTRIES_TOKEN=key
 ```
 
 메일 보내는것을 확인해야 하는경우 `MANDRILL_USERNAME`, `MANDRILL_APIKEY`, `RORLA_HOST`를 본인의 환경에 맞게 설정. 메일 보내는것이 중요하지 않으면 아무값이나 입력.

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -3,3 +3,7 @@ require File.expand_path('../application', __FILE__)
 
 # Initialize the Rails application.
 Rails.application.initialize!
+
+if Rails.env.production?
+  Rails.logger = Le.new(Rails.application.secrets.logentries_token)
+end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -20,3 +20,4 @@ test:
 # instead read values from the environment.
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+  logentries_token: <%= ENV["RORLA_LOGENTRIES_TOKEN"] %>


### PR DESCRIPTION
Docker 로그로 보면 불편하기도 하고 다른사람들이 확인 할 수 없어서 logentries 서비스 사용.
1달에 1기가 데이터 전송 무료.
비슷한 서비스로 loggly 가 있는데 레일스에 바로 붙여서 사용하기 불편.
