### PR TITLE
Bundlelink#as_collection 스코프의 boolean 형 지정 오류 수정

### DIFF
--- a/app/models/bundlelink.rb
+++ b/app/models/bundlelink.rb
@@ -23,6 +23,10 @@ class Bundlelink < ActiveRecord::Base
 
   scope :shared_bundles, -> { Bundlelink.where(shared: true) }
   scope :my_bundles, -> (user) { Bundlelink.where(writer: user)}
-  scope :as_collection, -> (user) { Bundlelink.where("shared = 't' or (writer_id = ? and shared = 'f')", user.id)}
+  if Rails.env == "production"
+    scope :as_collection, -> (user) { Bundlelink.where("shared = 1 or (writer_id = ? and shared = 0)", user.id)} 
+  else
+    scope :as_collection, -> (user) { Bundlelink.where("shared = 't' or (writer_id = ? and shared = 'f')", user.id)}
+  end
 
 end

--- a/app/views/favlinks/_favlink.html.erb
+++ b/app/views/favlinks/_favlink.html.erb
@@ -1,5 +1,5 @@
 <div class='favlink'>
-  <div class='title'><h4><%= link_to icon_label('share-alt', favlink.title), favlink.linkurl, style:'display:block;' %></h4></div>
+  <div class='title'><h4><%= link_to icon_label('share-alt', favlink.title), favlink.linkurl, target: '_blank', style:'display:block;' %></h4></div>
   <div class='linkurl'><%= icon_label('link', favlink.linkurl) %></div>
   <% if favlink.bundlelink %>
     <div class='bundle'><%= icon_label('book', link_to(favlink.bundlelink.try(:title), bundlelink_favlinks_path(favlink.bundlelink))) %></div>


### PR DESCRIPTION
sqlite와 mysql에서 boolean형 필드 조회시 문법상의 차이를 레일스 환경변수로 구분함.

``` ruby
class Bundlelink < ActiveRecord::Base
  ...
  if Rails.env == "production"
    scope :as_collection, -> (user) { Bundlelink.where("shared = 1 or (writer_id = ? and shared = 0)", user.id)} 
  else
    scope :as_collection, -> (user) { Bundlelink.where("shared = 't' or (writer_id = ? and shared = 'f')", user.id)}
  end
end
```
