### PR TITLE
rBlog 에디터의 autosize의 버그 해결함. 

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -45,4 +45,4 @@ $jumbotron-padding: 20px;
 @import 'podcasts';
 @import 'codebanks';
 
-body { padding-top: 60px; padding-bottom:80px; }
+body { padding-top: 60px;  }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -91,11 +91,11 @@
 
   </div> <!-- /container -->
 
-  <div class="navbar-fixed-bottom">
+  <!-- <div class="navbar-fixed-bottom"> -->
     <div id='footer'>
         Copyright<sup>&reg;</sup> <%= Time.new.year %>, RORLa Project, ROR Lab., All rights reserved.
     </div>
-  </div>
+  <!-- </div> -->
 
 </body>
 </html>


### PR DESCRIPTION
application 레이아웃 파일의 footer 섹션의 navbar-fixed-bottom 클래스를 제거하고, body 태그의 padding-bottom: 0;로 지정함.
