### PR TITLE
awesome_icon_shared_label 헬퍼 메소드 추가함.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -62,6 +62,10 @@ module ApplicationHelper
     shared ? awesome_icon('share-alt-square') : icon('lock')
   end
 
+  def awesome_icon_shared_label(shared, label)
+    (shared ? awesome_icon('share-alt-square') : icon('lock')) + ' ' + label
+  end
+
   def active_menu(*target_controller)
     target_controller.include?(controller_name) ? 'active' : ''
   end

--- a/app/views/codebanks/index.html.erb
+++ b/app/views/codebanks/index.html.erb
@@ -1,8 +1,6 @@
 <h2>
   <%= params[:whose] ? "나의 코드스니펫" : "코드뱅크" %>
   <small>
-    <%#= "filtered by <strong style=color:red;>'<u>#{params[:search]}</u>'</strong>".html_safe if params[:search] %>
-    <%#= "tagged with <span class='badge badge-default'>#{params[:tag]}</span>".html_safe if params[:tag] %>
     <%= params[:private] == '1' ? "<span class='badge badge-private'>private</span>".html_safe : (params[:whose] ? "<span class='badge badge-shared'>shared</span>".html_safe : "") %>
     (<%= @codebanks.total_entries %>)
     <%= link_to icon('remove-circle'), codebanks_path if params[:whose] || params[:search] || params[:tag] %>
@@ -21,7 +19,7 @@
   <tbody>
   <% @codebanks.each do |codebank| %>
       <tr>
-        <td class=""><%= link_to codebank.title, codebank %></td>
+        <td class=""><%= link_to awesome_icon_shared_label(codebank.shared, codebank.title), codebank %></td>
         <td class="hidden-sm hidden-xs"><%= codebank.writer.email %></td>
         <td class="hidden-xs"><%= codebank.created_at.strftime('%Y-%m-%d %l:%M:%S%P') %></td>
         <td class="visible-xs"><%= codebank.created_at.strftime('%Y-%m-%d') %></td>

--- a/app/views/codebanks/show.html.erb
+++ b/app/views/codebanks/show.html.erb
@@ -1,6 +1,6 @@
 <div class='codebank'>
 
-  <h2 class='title'><%= @codebank.title %></h2>
+  <h2 class='title'><%= awesome_icon_shared_label @codebank.shared, @codebank.title %></h2>
 
   <div class='summary'>
     :

--- a/app/views/favlinks/_favlink.html.erb
+++ b/app/views/favlinks/_favlink.html.erb
@@ -1,5 +1,5 @@
 <div class='favlink'>
-  <div class='title'><h4><%= link_to icon_shared(favlink.shared) + ' ' + favlink.title, favlink.linkurl, target: '_blank', style:'display:block;' %></h4></div>
+  <div class='title'><h4><%= link_to awesome_icon_shared_label(favlink.shared, favlink.title), favlink.linkurl, target: '_blank', style:'display:block;' %></h4></div>
   <div class='linkurl'><%= icon_label('link', favlink.linkurl) %></div>
   <% if favlink.bundlelink %>
     <div class='bundle'><%= icon_label('book', link_to(favlink.bundlelink.try(:title), bundlelink_favlinks_path(favlink.bundlelink))) %></div>


### PR DESCRIPTION
공유 불린값과 문자열을 넘기면 아이콘과 문자열이 함께 표시된다. 

```
  def awesome_icon(shape)
    "<span class='fa fa-#{shape}'></span>".html_safe
  end

  def awesome_icon_shared(shared)
    shared ? awesome_icon('share-alt-square') : icon('lock')
  end

  def awesome_icon_shared_label(shared, label)
    (shared ? awesome_icon('share-alt-square') : icon('lock')) + ' ' + label
  end

```
