### PR TITLE
alert_box_multiple 헬퍼 메소드 업데이트 함.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -130,12 +130,16 @@ module ApplicationHelper
       end)
       concat(content_tag(:h4, title))
       concat(content_tag(:ul) do
-        messages.map do |message|
-          content_tag :li, message
+        messages.map do |field, messages|
+          messages.map do |message|
+            content_tag :li, t("activerecord.attributes.question.#{field}") + message
+          end.join('').html_safe
         end.join('').html_safe
       end)
     end
   end
+
+
 
   def account_with_tooltip(email)
     content_tag :span, title: email, data:{toggle:'tooltip'} do

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,6 +1,6 @@
 <%= simple_form_for([@post.bulletin, @post]) do |f| %>
   <%#= f.error_notification %>
-  <%= alert_box_multiple('danger', "문제가 발생했습니다:", f.object.errors.full_messages) %>
+  <%= alert_box_multiple('danger', "문제가 발생했습니다:", f.object.errors.messages) if @post.errors.size > 0 %>
 
   <div class="form-group">
     <%= f.input :title, input_html:{ class: 'form-control'} %>

--- a/app/views/questions/_form.html.erb
+++ b/app/views/questions/_form.html.erb
@@ -1,14 +1,6 @@
 <%= simple_form_for(@question) do |f| %>
   <% if @question.errors.any? %>
-    <div id="error_explanation">
-      <ul>
-      <% @question.errors.messages.each do |field, messages| %>
-        <% messages.each do |message| %>
-          <li><%= t("labels.question.#{field}") %><%= message %></li>
-        <% end %>
-      <% end %>
-      </ul>
-    </div>
+    <%= alert_box_multiple('danger', "문제가 발생했습니다:", f.object.errors.messages) %>
   <% end %>
 
   <div class="form-group">


### PR DESCRIPTION
``` ruby
def alert_box_multiple(kind, title, messages)
  content_tag :div, role: "alert", class: "alert alert-#{kind} alert-dismissible" do
    concat(content_tag(:button, type: 'button', class: 'close', data: {dismiss: 'alert'}) do
      content_tag(:span, raw('&times;'), 'aria-hidden' => 'true') +
      content_tag(:span, 'Close', class:'sr-only')
    end)
    concat(content_tag(:h4, title))
    concat(content_tag(:ul) do
      messages.map do |field, messages|
        messages.map do |message|
          content_tag :li, t("activerecord.attributes.question.#{field}") + message
        end.join('').html_safe
      end.join('').html_safe
    end)
  end
end
```
