### PR TITLE
clock.rb 파일 수정

### DIFF
--- a/lib/clock.rb
+++ b/lib/clock.rb
@@ -8,6 +8,6 @@ module Clockwork
     puts `bin/rake podcasts:grap`
   }
   every(1.hour, 'merit.hourly_cron_job') { 
-    puts `bin/rake merit.hourly_cron_job`
+    puts `bin/rake merit:hourly_cron_job`
   }
 end


### PR DESCRIPTION
merit의  rake 작동 오류 해결 
puts `bin/rake merit.hourly_cron_job` -> puts `bin/rake merit:hourly_cron_job`
