### PR TITLE
직전 수정 원복(입금확인표시) 및 공동구매 테이블에 입금자 칼럼 추가

### DIFF
--- a/app/helpers/purchase_requests_helper.rb
+++ b/app/helpers/purchase_requests_helper.rb
@@ -2,11 +2,11 @@ module PurchaseRequestsHelper
   def purchase_confirmed(request)
     if user_signed_in? && current_user.can_confirm?(request)
       request.confirmed ?
-      link_to( request.sender_name.presence || "완료", confirm_purchase_path(request), data:{ confirm: "완료 취소하시겠습니까?"},  remote: true, class:'btn btn-success btn-xs') :
+      link_to( "완료", confirm_purchase_path(request), data:{ confirm: "완료 취소하시겠습니까?"},  remote: true, class:'btn btn-success btn-xs') :
       link_to( "미확인", confirm_purchase_path(request), data:{ confirm: "입금 확인을 원하십니까?"}, remote: true, class:'btn btn-danger btn-xs')
     else
       request.confirmed ?
-      content_tag(:div, request.sender_name.presence || "완료", class:'btn btn-success btn-xs') :
+      content_tag(:div, "완료", class:'btn btn-success btn-xs') :
       content_tag(:div, '미확인', class:'btn btn-danger btn-xs')
     end
   end

--- a/app/views/purchase_requests/index.html.erb
+++ b/app/views/purchase_requests/index.html.erb
@@ -20,6 +20,7 @@
       <th class='text-center'>신청자</th>
       <th class='text-center'>총수량</th>
       <th class='text-center'>입금확인</th>
+      <th class='text-center'>입금자</th>
       <th class='text-center'>입금액</th>
       <th class='text-center'>데이터작업</th>
     </tr>
@@ -34,6 +35,7 @@
         <td class='text-center' id="confirm_purchase_<%= purchase_request.id %>" >
           <%= purchase_confirmed(purchase_request) %>
         </td>
+        <td><%= purchase_request.sender_name.presence %></td>
         <td class='text-center'>
           <%#= purchase_request.confirmed_at ? purchase_request.confirmed_at : "n/a"%>
           <%= purchase_request.human_total_price %> 원


### PR DESCRIPTION
- 직전 수정 사항 원복
 - 직전 수정 사항: 입금확인 컬럼에서 "확인" -> "입금자 이름"으로 수정
 - 다시 "확인"으로 표시하도록 원복
- 공동구매 테이블 칼럼 추가
 - 입금확인 칼럼 오른쪽에 입금자 칼럼 추가